### PR TITLE
Add github release to publish workflow

### DIFF
--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -38,11 +38,41 @@ jobs:
           branch: main
           path: .
       
+      - name: Extract version
+        id: version
+        run: |
+          TAG=${{ github.ref }}
+          VERSION=${TAG#v}
+          echo "::set-output name=version::$VERSION"
+
       - name: Move files to dist
         run: |
           mkdir dist
           mv sdist/* dist/
-          
+          if [[ ! -f dist/multi_mst-${{ steps.version.outputs.version }}.tar.gz ]] ; then exit 1; fi
+
+      - name: Make github release
+        id: make_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          draft: false
+          prerelease: false
+          release_name: "Version ${{ steps.version.outputs.version }}"
+          tag_name: ${{ github.ref }}
+          body: "**Full Changelog**: https://github.com/vda-lab/multi_mst/commits/${{ github.ref }}"
+
+      - name: Upload source distribution
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.make_release.outputs.upload_url }}
+          asset_path: dist/*
+          asset_name: multi_mst-${{ steps.version.outputs.version }}.tar.gz
+          asset_content_type: application/gzip
+      
       - name: Publish package to (Test)PyPI
         uses: pypa/gh-action-pypi-publish@v1.8.5
         # Comment lines below to publish to PyPi instead of test PyPi

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = multi_mst
-version = 0.1.0
+version = 0.1.1
 author = Jelmer Bot
 author_email = jelmer.bot@uhasselt.be
 maintainer = Jelmer Bot


### PR DESCRIPTION
Have Github Actions create a Release when version tags are pushed and pypi is updated.
The release body should be updated manually after it is created for now.